### PR TITLE
Gh actions all branches

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,10 +1,6 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
-on:
-  push:
-    branches: [main, master]
-  pull_request:
-    branches: [main, master]
+on: [push, pull_request]
 
 name: R-CMD-check
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,10 +1,6 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
-on:
-  push:
-    branches: [main, master]
-  pull_request:
-    branches: [main, master]
+on: [push, pull_request]
 
 name: lint
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tfpbrowser
 Title: Builds Shiny application for 'tfpscanner' outputs
-Version: 0.0.7
+Version: 0.0.8
 Authors@R: 
     person("Jumping", "Rivers", , "info@jumpingrivers.com", role = c("aut", "cre"))
 Description: An R package to contain the code for the Shiny app to explore the 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# tfpbrowser 0.0.8 _2022-12-06_
+
+- make GH actions run on all branches (not just main)
+
 # tfpbrowser 0.0.7 _2022-12-01_
 
 - Fix: Remove ::: from unit tests


### PR DESCRIPTION
GitHub actions was previously only set to run on main and PRs to main, which means R CMD check and linting wasn't running on a couple of PRs.