### PR TITLE
fix: table formatting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 - Add bigger data set
 - Fix: ggiraph treeview was not correctly resizing
 - Fix: Make radio button choices depend on files available
+- Fix: Formatting of tables in dropdown
 
 # tfpbrowser 0.0.7 _2022-12-01_
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -60,29 +60,10 @@ get_all_files = function(cluster_choice) {
 #' function to tidy up table output
 #' @param table_to_display Data frame or tibble containing messy outputs
 reformat_table = function(table_to_display) {
-  if (nrow(table_to_display) == 1) {
-    output = table_to_display[, -1]$x
-    if (!is.na(output)) {
-      output = output %>%
-        stringr::str_split(pattern = "\n") %>%
-        unlist() %>%
-        stringr::str_trim() %>%
-        tibble::as_tibble() %>%
-        tidyr::separate(.data$value,
-                        into = c("x", "y"),
-                        sep = "  ",
-                        extra = "merge") %>%
-        dplyr::mutate(x = stringr::str_trim(.data$x),
-                      y = stringr::str_trim(.data$y)) %>%
-        `colnames<-`(.[1, ]) %>% # nolint
-        dplyr::slice(-1)
-    } else {
-      output = tibble::tibble(x = "Nothing to display")
-    }
-  } else {
-    output = janitor::clean_names(table_to_display,
-                                  case = "title")
+  if (all(unlist(table_to_display[,1]) == seq_len(nrow(table_to_display)))) {
+    table_to_display = table_to_display[, -1]
   }
+  output = janitor::clean_names(table_to_display, case = "title")
   return(output)
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -60,7 +60,7 @@ get_all_files = function(cluster_choice) {
 #' function to tidy up table output
 #' @param table_to_display Data frame or tibble containing messy outputs
 reformat_table = function(table_to_display) {
-  if (all(unlist(table_to_display[,1]) == seq_len(nrow(table_to_display)))) {
+  if (all(table_to_display[[1]] == seq_len(nrow(table_to_display)))) {
     table_to_display = table_to_display[, -1]
   }
   output = janitor::clean_names(table_to_display, case = "title")


### PR DESCRIPTION
Since updates to {tfpscanner} (from Erik's side I believe), csv files has data properly stored in rows and columns instead of all stored in cell A1. Most of the `reformat_table()` function is now unnecessary. The edits here now just checks if the first column is simply row numbers and, if so, removes it.

Closes #17 