### PR TITLE
Fix speed of app

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,8 @@ Imports:
     shinybrowser,
     shinyjs,
     stringr,
-    tibble
+    tibble,
+    waiter
 Suggests:
     shinytest2,
     testthat,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,8 +25,7 @@ Imports:
     shinybrowser,
     shinyjs,
     stringr,
-    tibble,
-    waiter
+    tibble
 Suggests:
     shinytest2,
     testthat,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tfpbrowser
 Title: Builds Shiny application for 'tfpscanner' outputs
-Version: 0.0.9
+Version: 0.0.10
 Authors@R: 
     person("Jumping", "Rivers", , "info@jumpingrivers.com", role = c("aut", "cre"))
 Description: An R package to contain the code for the Shiny app to explore the 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# tfpbrowser 0.0.10 _2022-12-18_
+
+- Fix: speed of app
+
 # tfpbrowser 0.0.9 _2022-12-18_
 
 - Add new tooltips with reduced info

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -22,6 +22,7 @@ app_server = function(input, output, session) {
 
   # create plotly output from saved ggplot2 outputs
   output$treeview = ggiraph::renderGirafe({
+    shiny::req(input$widgetChoice)
     filename = get_filename(input$widgetChoice)
     g = readRDS(filename)
     tooltip_css = paste0(
@@ -46,10 +47,13 @@ app_server = function(input, output, session) {
                         use_fill = FALSE)
                       )
                     ))
-  })
+  }) %>%
+    shiny::bindCache(input$widgetChoice)
 
   # get selected cluster id based on widget choice
   selected_cluster_id = shiny::reactive({
+    shiny::req(input$widgetChoice)
+    shiny::req(input$treeview_selected)
     get_selected_cluster_id(widgetChoice = input$widgetChoice,
                             treeviewSelected = input$treeview_selected)
   }) %>%

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -52,12 +52,14 @@ app_server = function(input, output, session) {
   selected_cluster_id = shiny::reactive({
     get_selected_cluster_id(widgetChoice = input$widgetChoice,
                             treeviewSelected = input$treeview_selected)
-  })
+  }) %>%
+    shiny::bindCache(input$widgetChoice, input$treeview_selected)
 
   # output result of click
   output$select_text = shiny::renderText({
     paste("You have selected cluster ID:", selected_cluster_id())
-  })
+  }) %>%
+    shiny::bindCache(input$widgetChoice, input$treeview_selected)
 
   # Tables Tab --------------------------------------------------------------
   tablesServer(

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -61,10 +61,10 @@ app_ui = function(request) {
 
           shiny::column(12,
 
-            # choose type of treeviw
+            # choose type of treeview
             shiny::radioButtons(inputId = "widgetChoice",
                                 label = "Select treeview",
-                                choices = available_treeview(),
+                                choices = c(c("None" = ""), available_treeview()),
                                 inline = TRUE),
 
             # show treeview widget

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -7,6 +7,7 @@ app_ui = function(request) {
 
     shinyjs::useShinyjs(),
     shinybrowser::detect(),
+    waiter::autoWaiter(id = "treeview", color = "#EBEEEE"),
 
     shiny::navbarPage(
       # title

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -7,7 +7,6 @@ app_ui = function(request) {
 
     shinyjs::useShinyjs(),
     shinybrowser::detect(),
-    waiter::autoWaiter(id = "treeview", color = "#EBEEEE"),
 
     shiny::navbarPage(
       # title

--- a/R/module_plots.R
+++ b/R/module_plots.R
@@ -24,7 +24,8 @@ plotsServer = function(id, cluster_choice) {
     # all available plots
     all_files = shiny::reactive({
       return(get_all_files(cluster_choice()))
-    })
+    }) %>%
+      shiny::bindCache(cluster_choice())
 
     # drop down for plots
     output$choose_plot = shiny::renderUI({
@@ -33,7 +34,8 @@ plotsServer = function(id, cluster_choice) {
       shiny::selectInput(ns("plot_type"),
                          label = "Select plot type:",
                          choices = all_images)
-    })
+    }) %>%
+      shiny::bindCache(cluster_choice())
 
     # get plot file
     plot_file = shiny::reactive({
@@ -42,7 +44,8 @@ plotsServer = function(id, cluster_choice) {
                               cluster_choice(), input$plot_type,
                               package = "tfpbrowser")
       return(plot_file)
-    })
+    }) %>%
+      shiny::bindCache(cluster_choice(), input$plot_type)
 
     # check if plots available
     plot_avail = shiny::reactive({

--- a/R/module_rds.R
+++ b/R/module_rds.R
@@ -22,25 +22,28 @@ rdsServer = function(id, cluster_choice) {
     # all available rds
     all_files = shiny::reactive({
       return(get_all_files(cluster_choice()))
-    })
+    }) %>%
+      shiny::bindCache(cluster_choice())
 
-    # drop down for plots
+    # drop down for rds
     output$choose_rds = shiny::renderUI({
       all_rds = filter_by_filetype(filenames = all_files(),
                                    filetypes = c("rds", "RDS"))
       shiny::selectInput(ns("rds_type"),
                          label = "Select RDS file:",
                          choices = all_rds)
-    })
+    }) %>%
+      shiny::bindCache(cluster_choice())
 
-    # get plot file
+    # get rds file
     rds_file = shiny::reactive({
       shiny::req(cluster_choice())
       rds_file = system.file("app", "www", "data", "scanner_output",
                               cluster_choice(), input$rds_type,
                               package = "tfpbrowser")
       return(rds_file)
-    })
+    }) %>%
+      shiny::bindCache(cluster_choice(), input$rds_type)
 
     # check if plots available
     rds_avail = shiny::reactive({

--- a/R/module_tables.R
+++ b/R/module_tables.R
@@ -22,7 +22,8 @@ tablesServer = function(id, cluster_choice) {
     # all available tables
     all_files = shiny::reactive({
       return(get_all_files(cluster_choice()))
-    })
+    }) %>%
+      shiny::bindCache(cluster_choice())
 
     # drop down for tables
     output$choose_table = shiny::renderUI({
@@ -31,7 +32,8 @@ tablesServer = function(id, cluster_choice) {
       shiny::selectInput(ns("table_type"),
                          label = "Select table type:",
                          choices = all_tables)
-    })
+    }) %>%
+      shiny::bindCache(cluster_choice())
 
     # get table file path
     table_file = shiny::reactive({
@@ -40,7 +42,8 @@ tablesServer = function(id, cluster_choice) {
                                cluster_choice(), input$table_type,
                                package = "tfpbrowser")
       return(table_file)
-    })
+    }) %>%
+      shiny::bindCache(cluster_choice(), input$table_type)
 
     # check if table available
     table_avail = shiny::reactive({


### PR DESCRIPTION
- add caching to dropdown selections, and cluster tooltip selection (this improves speed significantly when switching between nodes already clicked, and should see more improvements once deployed and we have multiple users who are likely to look at the same outputs)

- adding caching to the treeview widget caused the first treeview plot not to load (not entirely sure why - seems to be related to not clicking the choice of radio button?). To get around this, I've added and set the default option of the treeview to be "None". Has the added bonus of increasing the initial loading speed of the app.

Closes #20 
