### PR TITLE
fix: factors need to be characters

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tfpbrowser
 Title: Builds Shiny application for 'tfpscanner' outputs
-Version: 0.0.14
+Version: 0.0.15
 Authors@R: 
     person("Jumping", "Rivers", , "info@jumpingrivers.com", role = c("aut", "cre"))
 Description: An R package to contain the code for the Shiny app to explore

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# tfpbrowser 0.0.15 _2023-01-25_
+
+- Fix: available treeview options need to be characters
+
 # tfpbrowser 0.0.14 _2023-01-24_
 
 - Reorder radio buttons using factors

--- a/R/utils.R
+++ b/R/utils.R
@@ -2,15 +2,15 @@
 available_treeview = function() {
   all_trees = list.files(system.file("app", "www", "data", "treeview",
                                      package = "tfpbrowser"), pattern = "\\.rds$")
+  all_trees = factor(all_trees,
+                    c(stringr::str_subset(all_trees, "tree"),
+                      stringr::str_subset(all_trees, "sina")))
+  all_trees = as.character(sort(all_trees))
   names(all_trees) = all_trees %>%
     stringr::str_replace_all("_|-|\\.rds", " ") %>%
     stringr::str_trim() %>%
     stringr::str_to_title()
-
-  all_trees = factor(all_trees,
-                    c(stringr::str_subset(all_trees, "tree"),
-                      stringr::str_subset(all_trees, "sina")))
-  return(sort(all_trees))
+  return(all_trees)
 }
 
 #' function to return mutation options


### PR DESCRIPTION
Fixes a small bug where using factors meant the file wasn't found on displaying the treeview() - solution `as.character()`