### PR TITLE
Minor changes post deployment

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tfpbrowser
 Title: Builds Shiny application for 'tfpscanner' outputs
-Version: 0.0.20
+Version: 0.0.21
 Authors@R: 
     person("Jumping", "Rivers", , "info@jumpingrivers.com", role = c("aut", "cre"))
 Description: An R package to contain the code for the Shiny app to explore

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# tfpbrowser 0.0.21 _2023-03-01_
+
+- Fix: change to using `all_mutations` data
+- Fix: change wording of downloads
+
 # tfpbrowser 0.0.20 _2023-01-25_
 
 - Add function to get lookup of sequences and clusterID

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -30,7 +30,7 @@ app_ui = function(request) {
                         # use details and summary to create expandable section
                         htmltools::tags$details(
                           # preview of expandable section
-                          htmltools::tags$summary("Download Files (click to expand)"),
+                          htmltools::tags$summary("Cluster statistics (click to expand)"),
 
                           shiny::br(),
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -29,7 +29,7 @@ available_mutations = function() {
 #' @param chosen_mutation String for the user selected mutation
 selected_mut_nodes = function(chosen_mutation) {
   all_muts = readr::read_csv(system.file("app", "www", "data",
-                                         "mutations", "defining_mutations.csv",
+                                         "mutations", "all_mutations.csv",
                                          package = "tfpbrowser"),
                              col_types = readr::cols())
   selected_nodes = all_muts %>%

--- a/inst/app/www/content/treeview/tree-mutations.md
+++ b/inst/app/www/content/treeview/tree-mutations.md
@@ -1,1 +1,0 @@
-Some text describing the graph.


### PR DESCRIPTION
Using the all mutations data is something we had discussed at the previous meeting, so I've updated that as part of the existing work, and two very minor changes to text displayed.

- Fix: change to using `all_mutations` data
- Fix: change wording of downloads
- Fix: remove unneeded md text

Issues have been made for the remaining issues Erik mentioned.