### PR TITLE
Cluster stats help

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,7 @@ License: MIT + file LICENSE
 Depends: 
     R (>= 4.0.0)
 Imports:
+    bsicons,
     bslib,
     data.table,
     dplyr,

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -14,7 +14,7 @@ app_ui = function(request) {
       header = add_ext_resources(data_dir),
       # theme
       theme = bslib::bs_theme(
-        version = 4,
+        version = 5,
         bootswatch = "minty",
         bg = "#EBEEEE",
         fg = "#002147",

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -26,33 +26,7 @@ app_ui = function(request) {
       shiny::tabPanel(
         title = "Data",
         shiny::fluidRow(
-          shiny::column(
-            12,
-            # use details and summary to create expandable section
-            htmltools::tags$details(
-              # preview of expandable section
-              htmltools::tags$summary("Cluster statistics (click to expand)"),
-              shiny::br(),
-
-              # text to print choice
-              shiny::textOutput("select_text"),
-              shiny::br(),
-
-              # output options
-              shiny::tabsetPanel(
-                id = "plot_tabs",
-
-                # Tables tab
-                tablesUI("table1"),
-
-                # Plots tab
-                plotsUI("plot1"),
-
-                # RDS tab
-                rdsUI("rds1")
-              )
-            )
-          )
+          shiny::column(12, clusterStatsUI(id = NULL))
         ), # end fluid row
 
         # Bottom row - show tree (static html output from tfpscanner)

--- a/R/module_cluster_stats.R
+++ b/R/module_cluster_stats.R
@@ -1,0 +1,28 @@
+clusterStatsUI = function(id) {
+  ns = NS(id)
+
+  # use details and summary to create expandable section
+  htmltools::tags$details(
+    # preview of expandable section
+    htmltools::tags$summary("Cluster statistics (click to expand)"),
+    shiny::br(),
+
+    # text to print choice
+    shiny::textOutput(ns("select_text")),
+    shiny::br(),
+
+    # output options
+    shiny::tabsetPanel(
+      id = ns("plot_tabs"),
+
+      # Tables tab
+      tablesUI(ns("table1")),
+
+      # Plots tab
+      plotsUI(ns("plot1")),
+
+      # RDS tab
+      rdsUI(ns("rds1"))
+    )
+  )
+}

--- a/R/module_cluster_stats.R
+++ b/R/module_cluster_stats.R
@@ -1,7 +1,7 @@
 clusterStatsUI = function(id) {
-  ns = NS(id)
+  ns = shiny::NS(id)
 
-  box_content = tagList(
+  box_content = shiny::tagList(
     shiny::br(),
 
     # text to print choice
@@ -21,7 +21,7 @@ clusterStatsUI = function(id) {
 
   # Help icon for the cluster-statistics panel
   # - Clicking this icon does not lead to the underlying accordion_panel being expanded
-  help_text = tags$p(
+  help_text = shiny::tags$p(
     "The 'Cluster statistics' panel can be used to view or download data about a cluster.",
     "First, select a cluster by clicking on a node in one of the tree-views or scatter plots."
   )

--- a/R/module_cluster_stats.R
+++ b/R/module_cluster_stats.R
@@ -19,6 +19,11 @@ clusterStatsUI = function(id) {
     )
   )
 
+  help_text <- tags$p(
+    "The 'Cluster statistics' panel can be used to view or download data about a cluster.",
+    "First, select a cluster by clicking on a node in one of the tree-views or scatter plots."
+  )
+
   # use details and summary to create expandable section
   fluidRow(
     column(
@@ -31,7 +36,7 @@ clusterStatsUI = function(id) {
     ),
     column(
       width = 1,
-      bslib::popover(bsicons::bs_icon("question-circle"), "Help!")
+      bslib::popover(bsicons::bs_icon("question-circle"), help_text)
     )
   )
 }

--- a/R/module_cluster_stats.R
+++ b/R/module_cluster_stats.R
@@ -1,10 +1,7 @@
 clusterStatsUI = function(id) {
   ns = NS(id)
 
-  # use details and summary to create expandable section
-  htmltools::tags$details(
-    # preview of expandable section
-    htmltools::tags$summary("Cluster statistics (click to expand)"),
+  box_content = tagList(
     shiny::br(),
 
     # text to print choice
@@ -15,14 +12,17 @@ clusterStatsUI = function(id) {
     shiny::tabsetPanel(
       id = ns("plot_tabs"),
 
-      # Tables tab
+      # Tabs for "Tables", "Plots" and "RDS"
       tablesUI(ns("table1")),
-
-      # Plots tab
       plotsUI(ns("plot1")),
-
-      # RDS tab
       rdsUI(ns("rds1"))
     )
+  )
+
+  # use details and summary to create expandable section
+  htmltools::tags$details(
+    # preview of expandable section
+    htmltools::tags$summary("Cluster statistics (click to expand)"),
+    box_content
   )
 }

--- a/R/module_cluster_stats.R
+++ b/R/module_cluster_stats.R
@@ -19,24 +19,24 @@ clusterStatsUI = function(id) {
     )
   )
 
-  help_text <- tags$p(
+  # Help icon for the cluster-statistics panel
+  # - Clicking this icon does not lead to the underlying accordion_panel being expanded
+  help_text = tags$p(
     "The 'Cluster statistics' panel can be used to view or download data about a cluster.",
     "First, select a cluster by clicking on a node in one of the tree-views or scatter plots."
   )
+  help_popover = bsicons::bs_icon("question-circle") %>%
+    bslib::popover(help_text) %>%
+    htmltools::tagAppendAttributes(`data-bs-toggle` = "collapse", `data-bs-target` = NA)
 
-  # use details and summary to create expandable section
-  fluidRow(
-    column(
-      width = 11,
-      htmltools::tags$details(
-        # preview of expandable section
-        htmltools::tags$summary("Cluster statistics (click to expand)"),
-        box_content
-      )
-    ),
-    column(
-      width = 1,
-      bslib::popover(bsicons::bs_icon("question-circle"), help_text)
+  # Expandable panel containing the cluster-statistics details
+  bslib::accordion(
+    id = "cluster_stats_accordion",
+    open = FALSE,
+    bslib::accordion_panel(
+      title = "Cluster statistics (click to expand)",
+      box_content,
+      icon = help_popover
     )
   )
 }

--- a/R/module_cluster_stats.R
+++ b/R/module_cluster_stats.R
@@ -20,9 +20,18 @@ clusterStatsUI = function(id) {
   )
 
   # use details and summary to create expandable section
-  htmltools::tags$details(
-    # preview of expandable section
-    htmltools::tags$summary("Cluster statistics (click to expand)"),
-    box_content
+  fluidRow(
+    column(
+      width = 11,
+      htmltools::tags$details(
+        # preview of expandable section
+        htmltools::tags$summary("Cluster statistics (click to expand)"),
+        box_content
+      )
+    ),
+    column(
+      width = 1,
+      bslib::popover(bsicons::bs_icon("question-circle"), "Help!")
+    )
   )
 }

--- a/R/module_cluster_stats.R
+++ b/R/module_cluster_stats.R
@@ -25,7 +25,7 @@ clusterStatsUI = function(id) {
     "The 'Cluster statistics' panel can be used to view or download data about a cluster.",
     "First, select a cluster by clicking on a node in one of the tree-views or scatter plots."
   )
-  help_popover = bsicons::bs_icon("question-circle") %>%
+  help_popover = bsicons::bs_icon("question-circle", size = "1.5em") %>%
     bslib::popover(help_text) %>%
     htmltools::tagAppendAttributes(`data-bs-toggle` = "collapse", `data-bs-target` = NA)
 

--- a/inst/app/www/tfpbrowser-style.css
+++ b/inst/app/www/tfpbrowser-style.css
@@ -1,9 +1,8 @@
-summary {
-  background: #d6d6d6;
+.accordion-item {
   padding: 1em;
 }
 
-details {
+.accordion {
   margin-bottom: 2rem;
 }
 


### PR DESCRIPTION
Adds a help icon for the "Cluster statistics" panel. On clicking, this explains that the user should select a node in a tree-view, or in a scatter plot, and that data about that cluster can be downloaded or viewed within the cluster statistics panel.

~There may be better ways to implement this. I originally wanted the clickable icon to be inside the 'cluster statistics' accordion panel's title, but my attempts failed - on clicking the icon, the accordion panel opened, because icon-clicks propagated to the underlying accordion. This happened even if I added a click handler that (should have) prevented click propagation.~

The icon is added as a bootstrap popover. It therefore requires bootstrap v5. Hence, the project has been bumped to use bootstrap 5.

The UI component for the "Cluster statistics" is now generated by a function that is called by the main UI function. No matching server function has been added because the changes here only affected the UI-side of the app.

----

The help icon is now inside the title part of the accordion panel, and has been constructed so that clicking the icon causes the help text to be shown, but doesn't cause the underlying accordion to expand.